### PR TITLE
Add overlays for BL5340 to DTM application

### DIFF
--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -310,6 +310,32 @@ Use the following command:
 
 .. _dtm_testing:
 
+BL5340 and BL5340PA
+===================
+
+Direction finding is disabled in the overlays.
+
+When using the BL5340PA, the Laird Connectivity FEM driver handles antenna select for internal vs. external antenna variants. A hex file is required for each. Controlling antenna select using custom HCI VS DTM command is not supported because antenna select is part of Laird Connectivity FEM driver node.
+
+To build for the BL5340.
+
+.. code-block:: console
+
+   west build samples/bluetooth/direct_test_mode -p -b bl5340_dvk_cpunet
+
+To build for the BL5340PA with external antenna.
+
+.. code-block:: console
+
+   west build samples/bluetooth/direct_test_mode -p -b bl5340pa_dvk_cpunet
+
+
+To build for the internal antenna version without modifying DTS or overlay use the following command.
+
+.. code-block:: console
+
+   west build samples/bluetooth/direct_test_mode -p -b bl5340pa_dvk_cpunet -- -DCONFIG_LCZ_FEM_INTERNAL_ANTENNA=y
+
 Testing
 =======
 

--- a/samples/bluetooth/direct_test_mode/boards/bl5340_dvk_cpunet.conf
+++ b/samples/bluetooth/direct_test_mode/boards/bl5340_dvk_cpunet.conf
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_IPC_UART=y
+CONFIG_IPC_SERVICE=y
+CONFIG_IPC_SERVICE_BACKEND_RPMSG=y
+CONFIG_MBOX=y
+
+CONFIG_NRFX_DPPI=y
+
+CONFIG_HEAP_MEM_POOL_SIZE=4096
+
+# Build Remote shell APP Core sample for the application core
+CONFIG_NCS_SAMPLE_REMOTE_SHELL_CHILD_IMAGE=y

--- a/samples/bluetooth/direct_test_mode/boards/bl5340_dvk_cpunet.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/bl5340_dvk_cpunet.overlay
@@ -1,0 +1,18 @@
+/ {
+	chosen {
+		ncs,dtm-uart = &uart0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	compatible = "nordic,nrf-ipc-uart";
+	ipc = <&ipc0>;
+	ept-name = "remote shell";
+	current-speed = <19200>;
+};
+
+/* Disable direction finding */
+&radio {
+    /delete-property/ dfe-supported;
+};

--- a/samples/bluetooth/direct_test_mode/boards/bl5340pa_dvk_cpunet.conf
+++ b/samples/bluetooth/direct_test_mode/boards/bl5340pa_dvk_cpunet.conf
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_IPC_UART=y
+CONFIG_IPC_SERVICE=y
+CONFIG_IPC_SERVICE_BACKEND_RPMSG=y
+CONFIG_MBOX=y
+
+CONFIG_NRFX_DPPI=y
+
+CONFIG_HEAP_MEM_POOL_SIZE=4096
+
+# Build Remote shell APP Core sample for the application core
+CONFIG_NCS_SAMPLE_REMOTE_SHELL_CHILD_IMAGE=y

--- a/samples/bluetooth/direct_test_mode/boards/bl5340pa_dvk_cpunet.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/bl5340pa_dvk_cpunet.overlay
@@ -1,0 +1,18 @@
+/ {
+	chosen {
+		ncs,dtm-uart = &uart0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	compatible = "nordic,nrf-ipc-uart";
+	ipc = <&ipc0>;
+	ept-name = "remote shell";
+	current-speed = <19200>;
+};
+
+/* Disable direction finding */
+&radio {
+    /delete-property/ dfe-supported;
+};

--- a/samples/bluetooth/direct_test_mode/child_image/remote_shell/boards/bl5340_dvk_cpuapp.overlay
+++ b/samples/bluetooth/direct_test_mode/child_image/remote_shell/boards/bl5340_dvk_cpuapp.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,shell-ipc = &ipc0;
+		ncs,remote-shell-uart = &uart0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <19200>;
+};

--- a/samples/bluetooth/direct_test_mode/child_image/remote_shell/boards/bl5340pa_dvk_cpuapp.overlay
+++ b/samples/bluetooth/direct_test_mode/child_image/remote_shell/boards/bl5340pa_dvk_cpuapp.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,shell-ipc = &ipc0;
+		ncs,remote-shell-uart = &uart0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <19200>;
+};

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -33,3 +33,23 @@ tests:
       - nrf5340dk_nrf5340_cpunet
     platform_allow: nrf5340dk_nrf5340_cpunet
     tags: bluetooth ci_build
+  sample.bluetooth.direct_test_mode.bl5340:
+    build_only: true
+    integration_platforms:
+      - bl5340_dvk_cpunet
+    platform_allow: bl5340_dvk_cpunet
+    tags: bluetooth ci_build
+  sample.bluetooth.direct_test_mode.bl5340pa.ext:
+    build_only: true
+    integration_platforms:
+      - bl5340pa_dvk_cpunet
+    platform_allow: bl5340pa_dvk_cpunet
+    tags: bluetooth ci_build
+  sample.bluetooth.direct_test_mode.bl5340pa.int:
+    build_only: true
+    extra_configs:
+      - CONFIG_DTM_USB=y
+    integration_platforms:
+      - bl5340pa_dvk_cpunet
+    platform_allow: bl5340pa_dvk_cpunet
+    tags: bluetooth ci_build

--- a/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
@@ -24,16 +24,13 @@ enum nrf21540_ant {
 	NRF21540_ANT2
 };
 
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios)
 static struct nrf21540 {
-#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios)
 	const struct gpio_dt_spec ant_sel;
-#endif /* DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios) */
 } nrf21540_cfg = {
-#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios)
 	.ant_sel = GPIO_DT_SPEC_GET(NRF21540_NODE, ant_sel_gpios),
-#endif /* DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios) */
 };
-
+#endif /* DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios) */
 
 static int gpio_configure(void)
 {


### PR DESCRIPTION
Overlays are required to compile the DTM application for the BL5340 and BL5340PA DVKs.